### PR TITLE
Adding BTRFS support

### DIFF
--- a/odroid-backup.pl
+++ b/odroid-backup.pl
@@ -203,7 +203,7 @@ if($mainOperation eq 'backup'){
 
                             if ($partitions{$partition}{literalType} eq 'vfat' || $partitions{$partition}{literalType} eq 'btrfs') {
                                 #we use partclone
-                                $partcloneVersion = "partclone.$partitions{$partition}{literalType}";
+                                my $partcloneVersion = "partclone.$partitions{$partition}{literalType}";
                                 `$bin{$partcloneVersion} -c -s $partition -o "$directory/partition_${partitionNumber}.img" >> $logfile 2>&1`;
                                 $error = $? >> 8;
                                 `echo "Error code: $error" >> $logfile 2>&1`;

--- a/odroid-backup.pl
+++ b/odroid-backup.pl
@@ -201,9 +201,10 @@ if($mainOperation eq 'backup'){
                             $partition =~ /([0-9]+)$/;
                             my $partitionNumber = $1;
 
-                            if ($partitions{$partition}{literalType} eq 'vfat') {
+                            if ($partitions{$partition}{literalType} eq 'vfat' || $partitions{$partition}{literalType} eq 'btrfs') {
                                 #we use partclone
-                                `$bin{'partclone.vfat'} -c -s $partition -o "$directory/partition_${partitionNumber}.img" >> $logfile 2>&1`;
+                                $partcloneVersion = "partclone.$partitions{$partition}{literalType}";
+                                `$bin{$partcloneVersion} -c -s $partition -o "$directory/partition_${partitionNumber}.img" >> $logfile 2>&1`;
                                 $error = $? >> 8;
                                 `echo "Error code: $error" >> $logfile 2>&1`;
 
@@ -534,10 +535,8 @@ if($mainOperation eq 'restore'){
                                 $partitionDev = $selectedDisk.$partitionNumber;
                             }
                             
-                            if($partitions{$partition}{literalType} eq 'vfat' || $partitions{$partition}{literalType} eq 'FAT16' || $partitions{$partition}{literalType} eq 'FAT32'){
+                            if($partitions{$partition}{literalType} eq 'vfat' || $partitions{$partition}{literalType} eq 'btrfs' || $partitions{$partition}{literalType} eq 'FAT16' || $partitions{$partition}{literalType} eq 'FAT32'){
                                 #we use partclone
-                                
-                                
                                 `$bin{'partclone.restore'} -s '$partitions{$partitionNumber}{filename}' -o '/dev/$partitionDev' >> $logfile 2>&1`;
                                 $error = $? >> 8;
                                 `echo "Error code: $error" >> $logfile 2>&1`;

--- a/odroid-backup.pl
+++ b/odroid-backup.pl
@@ -23,6 +23,7 @@ my %dependencies = (
 'partclone.restore' => 'partclone',
 'partprobe' => 'parted',
 'flash_erase' => 'mtd-utils',
+'umount' => 'mount',
 );
 
 my $logfile = '/var/log/odroid-backup.log';
@@ -206,6 +207,7 @@ if($mainOperation eq 'backup'){
                                 #we use partclone
                                 my $partcloneVersion = 'partclone.' . $partitions{$partition}{literalType};
                                 `echo "Using partclone binary: $partcloneVersion" >> $logfile 2>&1`;
+                                `$bin{umount} $partition`; #partition can't be mounted while backing it up (eg. btrfs), so let's un-mount it
                                 `$bin{"$partcloneVersion"} -c -s $partition -o "$directory/partition_${partitionNumber}.img" >> $logfile 2>&1`;
                                 $error = $? >> 8;
                                 `echo "Error code: $error" >> $logfile 2>&1`;

--- a/odroid-backup.pl
+++ b/odroid-backup.pl
@@ -18,6 +18,7 @@ my %dependencies = (
 'blkid' => 'util-linux',
 'dd' => 'coreutils',
 'partclone.vfat' => 'partclone',
+'partclone.btrfs' => 'partclone',
 'partclone.info' => 'partclone',
 'partclone.restore' => 'partclone',
 'partprobe' => 'parted',
@@ -203,8 +204,9 @@ if($mainOperation eq 'backup'){
 
                             if ($partitions{$partition}{literalType} eq 'vfat' || $partitions{$partition}{literalType} eq 'btrfs') {
                                 #we use partclone
-                                my $partcloneVersion = "partclone.$partitions{$partition}{literalType}";
-                                `$bin{$partcloneVersion} -c -s $partition -o "$directory/partition_${partitionNumber}.img" >> $logfile 2>&1`;
+                                my $partcloneVersion = 'partclone.' . $partitions{$partition}{literalType};
+                                `echo "Using partclone binary: $partcloneVersion" >> $logfile 2>&1`;
+                                `$bin{"$partcloneVersion"} -c -s $partition -o "$directory/partition_${partitionNumber}.img" >> $logfile 2>&1`;
                                 $error = $? >> 8;
                                 `echo "Error code: $error" >> $logfile 2>&1`;
 


### PR DESCRIPTION
Hi, thanks for this superb script, it really eases up our life while backing up our ODroids! :)
I've tried to run the script on a HC1's microSD card in a memory card reader under Ubuntu 16.04 but it couldn't back up one partition which was BTRFS formatted (OMV 3 latest version). That partition was the main thing as it holds the OS itself, so I extended your script to work with this filesystem as well. I didn't (couldn't) test the restore part but according to the code, it should work. I'm also not proficient in Perl, so I needed to look up some string operations to learn how to do it but it works. All my partitions are backed up to the destination folder now without error. As `partclone.btrfs` can't back up such partitions while mounted, I needed to unmount it, however, this might not let the script run on live systems using the same SD card to operate, only in a card reader. But this way is fine for me, and I think it can help more people if you merge it. If you have some other solution to this particular case, feel free to add it. 